### PR TITLE
Resolve fatal due to mount and mkfs paths seeing different versions of cfg_table

### DIFF
--- a/src/fatfs_dev.c
+++ b/src/fatfs_dev.c
@@ -33,7 +33,7 @@ DWORD get_fattime(){
 	return time(0);
 }
 
-const void * cfg_table[_VOLUMES];
+static const void * cfg_table[_VOLUMES];
 
 static int reinitalize_drive(BYTE pdrv);
 
@@ -82,6 +82,11 @@ int fatfs_dev_open(BYTE pdrv){
 	const fatfs_config_t * cfg = cfg_table[pdrv];
 	int result;
 	drive_attr_t attr;
+
+	if (cfg == 0) {
+		mcu_debug_printf("FATFS: error, open with no cfg\n");
+		return 1;
+	}
 
 	if( FATFS_STATE(cfg)->drive.file.handle != 0 ){
 		//already initialized


### PR DESCRIPTION
There is error handling at the code session where the previous non-static variable would cause a crash.

To avoid the chicken-egg scenario, mount() is called first (from sos_default_thread). If mounting fails, then mkfs() is called before calling mount() again to mount the valid filesystem. If mkfs() is called first, it fails after f_mkfs() prints "2", because LD2PD() returns 0.